### PR TITLE
#8853 - Move the product description to appear at the right of the product image, above the product options and prices

### DIFF
--- a/assets/scss/_custom-papathemes.scss
+++ b/assets/scss/_custom-papathemes.scss
@@ -1,0 +1,11 @@
+.productView-description-customize {
+    ._head {
+        margin: 0 0 spacing("half");
+        font-size: fontSize("large");
+        font-weight: fontWeight("semibold");
+    }
+
+    p {
+        margin-bottom: spacing("quarter");
+    }
+}

--- a/assets/scss/theme.scss
+++ b/assets/scss/theme.scss
@@ -95,3 +95,5 @@
 @import "beautify/theme";
 
 @import "custom-inhealth";
+
+@import "custom-papathemes";

--- a/templates/components/products/product-view.html
+++ b/templates/components/products/product-view.html
@@ -128,7 +128,13 @@
                                     {{> components/yotpo/ratings id=product.id show_write=true}}
                                 {{/if}}
                             </div>
-
+                            <div class="productView-description-customize">
+                                <h2 class="_head" {{#if schema}} itemprop="description"{{/if}}>{{lang 'products.description'}}:</h2>
+                                <div class="_content">
+                                    {{{product.description}}}
+                                    {{{snippet 'product_description'}}}
+                                </div>
+                            </div>
                             <div class="productView-price">
                                 {{#if product.call_for_price}}
                                     <span class="price--call">{{product.call_for_price}}</span>
@@ -461,6 +467,7 @@
 
     <div data-also-bought-parent-scope class="productView-descriptionWrapper">
         <article class="productView-description">
+            {{!--
             <div class="tab-content is-active" id="tab-description">
                 {{#unless in_quickview}}<div class="container">{{/unless}}
                 <h2 class="beautify__page-heading _hasToggle">{{lang 'products.description'}}</h2>
@@ -474,6 +481,7 @@
                 </div>
                 {{#unless in_quickview}}</div><!-- .container -->{{/unless}}
             </div>
+            --}}
             {{#if product.videos.list.length}}
                 <div class="tab-content" id="tab-videos">
                     {{#unless in_quickview}}<div class="container">{{/unless}}


### PR DESCRIPTION
Issue link: https://github.com/orgs/allcommerce/projects/7/views/1?pane=issue&itemId=83026546&sortedBy%5Bdirection%5D=asc&sortedBy%5BcolumnId%5D=Assignees

--- Before:

![image](https://github.com/user-attachments/assets/9a5fdf92-9143-4525-b9c5-92558b4708a4)

--- After:

![image](https://github.com/user-attachments/assets/beedcec8-3e01-4fa4-b05e-56deb19c6245)
